### PR TITLE
analisando o base644_string do boby

### DIFF
--- a/src/betamax/cassette/interaction.py
+++ b/src/betamax/cassette/interaction.py
@@ -83,14 +83,18 @@ class Interaction(object):
             body = self.data[obj]['body']
             old_style = hasattr(body, 'replace')
             if not old_style:
-                body = body.get('string', '')
+                key = 'string'
+                if not body.setdefault(key, '')\
+                        and body.get('base64_string', ''):
+                    key = 'base64_string'
+                body = body[key]
 
             if text_to_replace in body:
                 body = body.replace(text_to_replace, placeholder)
             if old_style:
                 self.data[obj]['body'] = body
             else:
-                self.data[obj]['body']['string'] = body
+                self.data[obj]['body'][key] = body
 
     def replace_in_uri(self, text_to_replace, placeholder):
         for (obj, key) in (('request', 'uri'), ('response', 'url')):


### PR DESCRIPTION
Quando o servidor aceite a codificação em GZIP, as infos de autenticação ficam em base64 e são salvas no campo base64_string do cassette. Ideia é averiguar esse campo caso não tenha nada de string e substituir por outro valor, utilizando a codificação em base64.